### PR TITLE
Added support for configurable aws profile 

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,5 @@ extends:
     - airbnb
 rules:
     strict: off
-
 env:
     mocha: true

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const _ = require('underscore');
 class VPCPlugin {
   constructor(serverless) {
     this.serverless = serverless;
-    const awsProvider = this.serverless.providers.aws.getCredentials();
+    const awsCreds = this.serverless.providers.aws.getCredentials();
 
-    AWS.config.update(awsProvider);
+    AWS.config.update(awsCreds);
     this.ec2 = new AWS.EC2();
 
     /* hooks are the acutal code that will run when called */

--- a/index.js
+++ b/index.js
@@ -6,9 +6,11 @@ const _ = require('underscore');
 class VPCPlugin {
   constructor(serverless) {
     this.serverless = serverless;
-    AWS.config.update({
-      region: serverless.service.provider.region,
-    });
+    const awsProvider = this.serverless.providers.aws.getCredentials();
+    if (awsProvider.credentials == null) {
+      throw new Error('AWS Provider was not set')
+    }
+    AWS.config.update(awsProvider);
     this.ec2 = new AWS.EC2();
 
     /* hooks are the acutal code that will run when called */

--- a/index.js
+++ b/index.js
@@ -7,9 +7,7 @@ class VPCPlugin {
   constructor(serverless) {
     this.serverless = serverless;
     const awsProvider = this.serverless.providers.aws.getCredentials();
-    if (awsProvider.credentials == null) {
-      throw new Error('AWS Provider was not set')
-    }
+
     AWS.config.update(awsProvider);
     this.ec2 = new AWS.EC2();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-discovery",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,7 +13,7 @@ const expect = chai.expect;
 const testCreds = {
   accessKeyId: 'test_key',
   secretAccessKey: 'test_secret',
-  sessionToken: 'test_session'
+  sessionToken: 'test_session',
 };
 const vpc = 'ci';
 const subnets = [
@@ -25,7 +25,7 @@ const securityGroups = ['test_group_1'];
 const vpcId = 'vpc-test';
 
 // This will create a mock plugin to be used for testing
-const constructPlugin = (vpcConfig, test_credentials) => {
+const constructPlugin = (vpcConfig) => {
   const serverless = {
     service: {
       provider: {
@@ -41,11 +41,9 @@ const constructPlugin = (vpcConfig, test_credentials) => {
     },
     providers: {
       aws: {
-        getCredentials: function () {
-          return new aws.Credentials (testCreds);
-        }
-      }
-    }
+        getCredentials: () => new aws.Credentials(testCreds),
+      },
+    },
   };
   return new VPCPlugin(serverless);
 };
@@ -54,8 +52,8 @@ describe('serverless-vpc-plugin', () => {
   it('check aws config', () => {
     const plugin = constructPlugin({}, 'tests');
     const returnedCreds = plugin.ec2.config.credentials;
-    expect(returnedCreds['accessKeyId']).to.equal(testCreds['accessKeyId']);
-    expect(returnedCreds['sessionToken']).to.equal(testCreds['sessionToken']);
+    expect(returnedCreds.accessKeyId).to.equal(testCreds.accessKeyId);
+    expect(returnedCreds.sessionToken).to.equal(testCreds.sessionToken);
   });
 
   it('registers hooks', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@
 
 const chai = require('chai');
 const AWS = require('aws-sdk-mock');
+const aws = require('aws-sdk');
 const testData = require('./test-data.json');
 const emptyData = require('./empty-data.json');
 const VPCPlugin = require('../index.js');
@@ -9,6 +10,11 @@ const VPCPlugin = require('../index.js');
 const expect = chai.expect;
 
 // Used for changing what to test
+const testCreds = {
+  accessKeyId: 'test_key',
+  secretAccessKey: 'test_secret',
+  sessionToken: 'test_session'
+};
 const vpc = 'ci';
 const subnets = [
   'test_subnet_1',
@@ -19,7 +25,7 @@ const securityGroups = ['test_group_1'];
 const vpcId = 'vpc-test';
 
 // This will create a mock plugin to be used for testing
-const constructPlugin = (vpcConfig) => {
+const constructPlugin = (vpcConfig, test_credentials) => {
   const serverless = {
     service: {
       provider: {
@@ -33,13 +39,27 @@ const constructPlugin = (vpcConfig) => {
       log() {
       },
     },
+    providers: {
+      aws: {
+        getCredentials: function () {
+          return new aws.Credentials (testCreds);
+        }
+      }
+    }
   };
   return new VPCPlugin(serverless);
 };
 
 describe('serverless-vpc-plugin', () => {
+  it('check aws config', () => {
+    const plugin = constructPlugin({}, 'tests');
+    const returnedCreds = plugin.ec2.config.credentials;
+    expect(returnedCreds['accessKeyId']).to.equal(testCreds['accessKeyId']);
+    expect(returnedCreds['sessionToken']).to.equal(testCreds['sessionToken']);
+  });
+
   it('registers hooks', () => {
-    const plugin = constructPlugin({}, {});
+    const plugin = constructPlugin({});
     expect(plugin.hooks['before:deploy:initialize']).to.be.a('function');
   });
 });


### PR DESCRIPTION
Can now use `--aws-profile` or add `profile` to the serverless file under `provider`.