### PR TITLE
Add More Retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.13] - 2018-10-10
+### Added
+- Added our own configuration for AWS SDK's built in retry mechanism, increasing it from 3 retries to 20 so that this plugin is more easily used in an automated environment.
 
 ## [1.0.12] - 2018-08-01
-
 ### Added
 - This CHANGELOG file to make it easier for future updates to be documented. Sadly, will not be going back to document changes made for previous versions.

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ class VPCPlugin {
     const awsCreds = this.serverless.providers.aws.getCredentials();
 
     AWS.config.update(awsCreds);
+    AWS.config.update({
+      maxRetries: 20,
+    });
+
     this.ec2 = new AWS.EC2();
 
     this.serverless.cli.log('Updating VPC config...');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-discovery",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Sometimes, the AWS commands this plugin uses timeout. When that happens,
the plugin currently fails out and the user must run the deploy again. That
is bad for automated environments where we want to run deploys seamlessly.
So let's add our own maxRetries to the AWS config object we get from
serverless and make sure that we retry throttled commands automatically.

The default is 3 retries, and this change raises that to 20 retries, which should be sufficient.