### PR TITLE
Allow multiple resources with same name tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ class VPCPlugin {
         throw new Error('Invalid subnet name, it does not exist');
       }
 
-      if (paramsSubnet.Filters[1].Values.length !== data.Subnets.length) {
+      if (paramsSubnet.Filters[1].Values.length > data.Subnets.length) {
         // Creates a list of the valid subnets
         const validSubnets = data.Subnets.reduce((accum, val) => {
           const nameTag = val.Tags.find(tag => tag.Key === 'Name');
@@ -155,7 +155,7 @@ class VPCPlugin {
         throw new Error('Invalid security group name, it does not exist');
       }
 
-      if (paramsSecurity.Filters[1].Values.length !== data.SecurityGroups.length) {
+      if (paramsSecurity.Filters[1].Values.length > data.SecurityGroups.length) {
         const validGroups = data.SecurityGroups.map(obj => obj.GroupName);
         const missingGroups = _.difference(paramsSecurity.Filters[1].Values, validGroups);
         throw new Error(`Not all security group were registered: ${missingGroups}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-discovery",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "engines": {
     "node": ">=4.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,8 +20,9 @@ const subnets = [
   'test_subnet_1',
   'test_subnet_2',
   'test_subnet_3',
+  'common_name',
 ];
-const securityGroups = ['test_group_1'];
+const securityGroups = ['test_group_1', 'common_name'];
 const vpcId = 'vpc-test';
 
 // This will create a mock plugin to be used for testing

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,8 +88,8 @@ describe('Given a vpc,', () => {
 
     return plugin.updateVpcConfig().then((data) => {
       expect(data).to.eql({
-        securityGroupIds: ['sg-test'],
-        subnetIds: ['subnet-test-1', 'subnet-test-2', 'subnet-test-3'],
+        securityGroupIds: ['sg-test', 'sg-test2', 'sg-test3'],
+        subnetIds: ['subnet-test-1', 'subnet-test-2', 'subnet-test-3', 'subnet-test-4', 'subnet-test-5'],
       });
     });
   });

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37,12 +37,42 @@
           "Value": "test_subnet_3"
         }
       ]
+    },
+    {
+      "SubnetId": "subnet-test-4",
+      "State": "available",
+      "VpcId": "vpc-test",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "common_name"
+        }
+      ]
+    },
+    {
+      "SubnetId": "subnet-test-5",
+      "State": "available",
+      "VpcId": "vpc-test",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "common_name"
+        }
+      ]
     }
   ],
   "SecurityGroups": [
     {
       "GroupId": "sg-test",
       "GroupName": "test_group_1"
+    },
+    {
+      "GroupId": "sg-test2",
+      "GroupName": "common_name"
+    },
+    {
+      "GroupId": "sg-test3",
+      "GroupName": "common_name"
     }
   ]
 }


### PR DESCRIPTION
On our setup, we have several Subnets and Security Groups associated with our VPC.  

The motivation is instead of having name our subnets differently and having to specify each of name in `serverless.yml`, we add a common label to them all such as `private_rds` to all of them, allowing our plugin setup to look like this:

```yaml
custom:
  vpc:
    vpcName: 'whatever'
    subnetNames:
      - 'private_rds'
    securityGroupNames:
      - 'private_rds'
```

This will match all subnets\security groups who share that name.

To achieve that, the assertion that the plugin makes that the number of parameters must match exactly the number of subnets found for them must be changed to allow less parameters than resources found.  
In less resources than parameters are found, the plugin will fail as it used to.  