### PR TITLE
Configurare at function level

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,4 +172,5 @@ class VPCPlugin {
     });
   }
 }
+
 module.exports = VPCPlugin;

--- a/index.js
+++ b/index.js
@@ -54,13 +54,16 @@ class VPCPlugin {
 
         // Sets the serverless's vpc config
         if (service.functions) {
-          Object.values(service.functions).filter(f => f.vpc === undefined).forEach((f) => {
+          Object.values(service.functions)
+            .filter(f => (!service.custom.vpc.disable && f.vpc === undefined)
+              || (service.custom.vpc.disable && f.vpc === service.custom.vpc.vpcName))
+            .forEach((f) => {
             // eslint-disable-next-line no-param-reassign
-            f.vpc = {
-              subnetIds: values[0],
-              securityGroupIds: values[1],
-            };
-          });
+              f.vpc = {
+                subnetIds: values[0],
+                securityGroupIds: values[1],
+              };
+            });
         }
 
         return service.functions;

--- a/index.js
+++ b/index.js
@@ -55,8 +55,12 @@ class VPCPlugin {
         // Sets the serverless's vpc config
         if (service.functions) {
           Object.values(service.functions)
-            .filter(f => (!service.custom.vpc.disable && f.vpc === undefined)
-              || (service.custom.vpc.disable && f.vpc === service.custom.vpc.vpcName))
+            .filter((f) => {
+              const noVpcDefinedForFunction = f.vpc === undefined;
+              const vpcNameEquals = f.vpc && f.vpc.vpcName === service.custom.vpc.vpcName;
+              return (!service.custom.vpc.disable && noVpcDefinedForFunction)
+                || (service.custom.vpc.disable && vpcNameEquals);
+            })
             .forEach((f) => {
             // eslint-disable-next-line no-param-reassign
               f.vpc = {

--- a/index.js
+++ b/index.js
@@ -51,14 +51,14 @@ class VPCPlugin {
           throw new Error('Vpc was not set');
         }
 
-        service.functions.filter(f => f.vpc === undefined).forEach((f) => {
+        // Sets the serverless's vpc config
+        Object.values(service.functions).filter(f => f.vpc === undefined).forEach((f) => {
           // eslint-disable-next-line no-param-reassign
           f.vpc = {
             subnetIds: values[0],
             securityGroupIds: values[1],
           };
         });
-        // Sets the serverless's vpc config
 
         return service.provider.vpc;
       }));

--- a/index.js
+++ b/index.js
@@ -51,11 +51,14 @@ class VPCPlugin {
           throw new Error('Vpc was not set');
         }
 
+        service.functions.filter(f => f.vpc === undefined).forEach((f) => {
+          // eslint-disable-next-line no-param-reassign
+          f.vpc = {
+            subnetIds: values[0],
+            securityGroupIds: values[1],
+          };
+        });
         // Sets the serverless's vpc config
-        service.provider.vpc = {
-          subnetIds: values[0],
-          securityGroupIds: values[1],
-        };
 
         return service.provider.vpc;
       }));

--- a/index.js
+++ b/index.js
@@ -52,15 +52,17 @@ class VPCPlugin {
         }
 
         // Sets the serverless's vpc config
-        Object.values(service.functions).filter(f => f.vpc === undefined).forEach((f) => {
-          // eslint-disable-next-line no-param-reassign
-          f.vpc = {
-            subnetIds: values[0],
-            securityGroupIds: values[1],
-          };
-        });
+        if (service.functions) {
+          Object.values(service.functions).filter(f => f.vpc === undefined).forEach((f) => {
+            // eslint-disable-next-line no-param-reassign
+            f.vpc = {
+              subnetIds: values[0],
+              securityGroupIds: values[1],
+            };
+          });
+        }
 
-        return service.provider.vpc;
+        return service.functions;
       }));
     }).catch((err) => {
       throw new Error(`Could not set vpc config. Message: ${err}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-discovery",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "engines": {
     "node": ">=4.0"
   },


### PR DESCRIPTION
Resolves #15 

This PR changes the plugin to set the VPC up on each function, rather than on the provider.  
According to the Serverless documentation the effect is equivalent, and that is the only way to override the provider VPCs with `null` base on https://github.com/serverless/serverless/issues/4387#issuecomment-498950542 .

Here's an example:

```yml
plugins:
  - serverless-vpc-discovery

custom:
  vpc:
    vpcName: '${opt:env}'
    subnetNames:
      - '${opt:env}_NAME OF SUBNET'
    securityGroupNames:
      - '${opt:env}_NAME OF SECURITY GROUP'

functions:
  foo:
    ...     # will reside in vpc discovered by `serverless-vpc-discovery`

  bar:
    vpc: ~  # will not reside in any VPC
    ...

  fooBar:   # will reside in the VPC provided, overriding the one discovered by the plugin
    vpc: 
        subnetIds:
          ...
        securityGroupIds:
          ...
```