### PR TITLE
Allows looking up subnet OR security group...doesn't require both

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ custom:
       - '${opt:env}_NAME OF SUBNET'
     securityGroupNames:
       - '${opt:env}_NAME OF SECURITY GROUP'
+    disable: true (sets at function level), false (sets at provider level)
 ```
 > NOTE: The naming pattern we used here was building off the vpc name for the subnet and security group by extending it with the the subnet and security group name. This makes it easier to switch to different vpcs by changing the environment variable in the command line
 

--- a/index.js
+++ b/index.js
@@ -54,13 +54,16 @@ class VPCPlugin {
 
         // Sets the serverless's vpc config
         if (service.functions) {
-          Object.values(service.functions).filter(f => f.vpc === undefined).forEach((f) => {
+          Object.values(service.functions)
+            .filter(f => (!service.custom.vpc.disable && f.vpc === undefined)
+              || (service.custom.vpc.disable && f.vpc === service.custom.vpc.vpcName))
+            .forEach((f) => {
             // eslint-disable-next-line no-param-reassign
-            f.vpc = {
-              subnetIds: values[0],
-              securityGroupIds: values[1],
-            };
-          });
+              f.vpc = {
+                subnetIds: values[0],
+                securityGroupIds: values[1],
+              };
+            });
         }
 
         return service.functions;

--- a/index.js
+++ b/index.js
@@ -55,8 +55,12 @@ class VPCPlugin {
         // Sets the serverless's vpc config
         if (service.functions) {
           Object.values(service.functions)
-            .filter(f => (!service.custom.vpc.disable && f.vpc === undefined)
-              || (service.custom.vpc.disable && f.vpc === service.custom.vpc.vpcName))
+            .filter((f) => {
+              const noVpcDefinedForFunction = f.vpc === undefined;
+              const vpcNameEquals = f.vpc && f.vpc.vpcName === service.custom.vpc.vpcName;
+              return (!service.custom.vpc.disable && noVpcDefinedForFunction)
+                || (service.custom.vpc.disable && vpcNameEquals);
+            })
             .forEach((f) => {
             // eslint-disable-next-line no-param-reassign
               f.vpc = {

--- a/index.js
+++ b/index.js
@@ -71,7 +71,6 @@ console.log('functions:',service.functions);
                 || (service.custom.vpc.disable && vpcNameEquals);
             })
             .forEach((f) => {
-              f.vpc = {};
 console.log('vpc functions:',f)
 console.log('vpcs values:', values)
               if (service.custom.vpc.subnetNames && service.custom.vpc.securityGroupNames) {

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ class VPCPlugin {
 
         // Sets the serverless's vpc config
         if (service.functions) {
+console.log('functions:',service.functions);          
           Object.values(service.functions)
             .filter((f) => {
               const noVpcDefinedForFunction = f.vpc === undefined;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const AWS = require('aws-sdk');
 const _ = require('underscore');
 
 class VPCPlugin {
@@ -19,15 +18,10 @@ class VPCPlugin {
    * @returns {Promise}
    */
   updateVpcConfig() {
-    const awsCreds = this.serverless.providers.aws.getCredentials();
-    awsCreds.region = this.serverless.providers.aws.getRegion();
-
-    AWS.config.update(awsCreds);
-    AWS.config.update({
+    this.ec2 = new this.serverless.providers.aws.sdk.EC2({
       maxRetries: 20,
+      region: this.serverless.providers.aws.getRegion()
     });
-
-    this.ec2 = new AWS.EC2();
 
     this.serverless.cli.log('Updating VPC config...');
     const service = this.serverless.service;

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ class VPCPlugin {
         throw new Error('Invalid subnet name, it does not exist');
       }
 
-      if (paramsSubnet.Filters[1].Values.length !== data.Subnets.length) {
+      if (paramsSubnet.Filters[1].Values.length > data.Subnets.length) {
         // Creates a list of the valid subnets
         const validSubnets = data.Subnets.reduce((accum, val) => {
           const nameTag = val.Tags.find(tag => tag.Key === 'Name');
@@ -155,7 +155,7 @@ class VPCPlugin {
         throw new Error('Invalid security group name, it does not exist');
       }
 
-      if (paramsSecurity.Filters[1].Values.length !== data.SecurityGroups.length) {
+      if (paramsSecurity.Filters[1].Values.length > data.SecurityGroups.length) {
         const validGroups = data.SecurityGroups.map(obj => obj.GroupName);
         const missingGroups = _.difference(paramsSecurity.Filters[1].Values, validGroups);
         throw new Error(`Not all security group were registered: ${missingGroups}`);

--- a/index.js
+++ b/index.js
@@ -62,7 +62,6 @@ class VPCPlugin {
 
         // Sets the serverless's vpc config
         if (service.functions) {
-console.log('functions:',service.functions);          
           Object.values(service.functions)
             .filter((f) => {
               const noVpcDefinedForFunction = f.vpc === undefined;
@@ -71,8 +70,6 @@ console.log('functions:',service.functions);
                 || (service.custom.vpc.disable && vpcNameEquals);
             })
             .forEach((f) => {
-console.log('vpc functions:',f)
-console.log('vpcs values:', values)
               if (service.custom.vpc.subnetNames && service.custom.vpc.securityGroupNames) {
                 f.vpc.subnetIds = values[0];
                 f.vpc.securityGroupIds = values[1];

--- a/index.js
+++ b/index.js
@@ -71,7 +71,8 @@ class VPCPlugin {
             })
             .forEach((f) => {
               f.vpc = {};
-
+console.log('vpc functions:',f)
+console.log('vpcs values:', values)
               if (service.custom.vpc.subnetNames && service.custom.vpc.securityGroupNames) {
                 f.vpc.subnetIds = values[0];
                 f.vpc.securityGroupIds = values[1];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corydorning/serverless-vpc-discovery",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@env0/serverless-vpc-discovery",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corydorning/serverless-vpc-discovery",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-discovery",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corydorning/serverless-vpc-discovery",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "serverless-vpc-discovery",
-  "version": "1.0.14",
+  "name": "@env0/serverless-vpc-discovery",
+  "version": "1.0.15",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@env0/serverless-vpc-discovery",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@corydorning/serverless-vpc-discovery",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "engines": {
     "node": ">=4.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@env0/serverless-vpc-discovery",
+  "name": "@corydorning/serverless-vpc-discovery",
   "version": "1.0.18",
   "engines": {
     "node": ">=4.0"
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/amplify-education/serverless-vpc-discovery"
+    "url": "git+https://github.com/amplify-education/serverless-vpc-discovery.git"
   },
   "keywords": [
     "serverless discovery VPC",
@@ -24,7 +24,6 @@
     "serverless.com"
   ],
   "main": "index.js",
-  "bin": {},
   "scripts": {
     "test": "node ./node_modules/istanbul/lib/cli.js cover _mocha -- -R spec && node ./node_modules/istanbul/lib/cli.js check-coverage --line 70 coverage/coverage.json",
     "lint": "eslint ."
@@ -43,5 +42,12 @@
   "dependencies": {
     "aws-sdk": "^2.2.33",
     "underscore": "^1.8.3"
+  },
+  "bugs": {
+    "url": "https://github.com/amplify-education/serverless-vpc-discovery/issues"
+  },
+  "homepage": "https://github.com/amplify-education/serverless-vpc-discovery#readme",
+  "directories": {
+    "test": "test"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,8 +20,9 @@ const subnets = [
   'test_subnet_1',
   'test_subnet_2',
   'test_subnet_3',
+  'common_name',
 ];
-const securityGroups = ['test_group_1'];
+const securityGroups = ['test_group_1', 'common_name'];
 const vpcId = 'vpc-test';
 
 // This will create a mock plugin to be used for testing

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -88,8 +88,8 @@ describe('Given a vpc,', () => {
 
     return plugin.updateVpcConfig().then((data) => {
       expect(data).to.eql({
-        securityGroupIds: ['sg-test'],
-        subnetIds: ['subnet-test-1', 'subnet-test-2', 'subnet-test-3'],
+        securityGroupIds: ['sg-test', 'sg-test2', 'sg-test3'],
+        subnetIds: ['subnet-test-1', 'subnet-test-2', 'subnet-test-3', 'subnet-test-4', 'subnet-test-5'],
       });
     });
   });

--- a/test/test-data.json
+++ b/test/test-data.json
@@ -37,12 +37,42 @@
           "Value": "test_subnet_3"
         }
       ]
+    },
+    {
+      "SubnetId": "subnet-test-4",
+      "State": "available",
+      "VpcId": "vpc-test",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "common_name"
+        }
+      ]
+    },
+    {
+      "SubnetId": "subnet-test-5",
+      "State": "available",
+      "VpcId": "vpc-test",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "common_name"
+        }
+      ]
     }
   ],
   "SecurityGroups": [
     {
       "GroupId": "sg-test",
       "GroupName": "test_group_1"
+    },
+    {
+      "GroupId": "sg-test2",
+      "GroupName": "common_name"
+    },
+    {
+      "GroupId": "sg-test3",
+      "GroupName": "common_name"
     }
   ]
 }


### PR DESCRIPTION
Originally forked from env0 which includes pr 18 and 19 and disable:
https://github.com/env0/serverless-vpc-discovery/releases/tag/1.0.14-pr-18-19-plus-disable-rerelease

Didn't update the unit tests because i've only really worked with jest. happy to make any changes if needed.