### PR TITLE
Optional `custom.vpcDiscovery`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ script:
 before_deploy:
   - npm run build
 deploy:
-  skip_cleanup: true
   provider: npm
+  edge: true
+  cleanup: true
   email: $NPM_EMAIL
   api_key: $NPM_KEY
   on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.2.0] - 2020-12-01
+## [2.2.0] - 2020-12-02
 ### Changed
 - Set `custom.vpcDiscovery` optional.
 - Update travis config for github release tagging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2020-12-01
+### Changed
+- Set `custom.vpcDiscovery` optional. Updated readme.
+- Update travis config for github release tagging
+
 ## [2.1.0] - 2020-11-17
 ### Changed
 - ***Important!*** The `vpc` option has been deprecated but it still will work for a while. The new option is `vpcDiscovery`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.2.0] - 2020-12-01
 ### Changed
-- Set `custom.vpcDiscovery` optional. Updated readme.
+- Set `custom.vpcDiscovery` optional.
 - Update travis config for github release tagging
 
 ## [2.1.0] - 2020-11-17

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Basically we use this config:
 vpcDiscovery:
     vpcName: '${opt:env}'
     subnetNames: # optional if securityGroupNames are specified
-      - '${opt:env}_NAME OF SUBNET'
+      - '${opt:env}_<name of subnet>'
     securityGroupNames: # optional if subnetNames are specified
-      - '${opt:env}_NAME OF SECURITY GROUP'
+      - '${opt:env}_<name of security group>'
 ```
 To generate this config:
 ```
@@ -27,8 +27,9 @@ vpc:
         - sg-123456789
         ...
 ```
-For each lambda function
+For each lambda function.
       
+> Note: The plugin can be used with the core serverless vpc config. Take a look at [official documentation](https://www.serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration). 
 
 # About Amplify
 Amplify builds innovative and compelling digital educational products that empower teachers and students across the country. We have a long history as the leading innovator in K-12 education - and have been described as the best tech company in education and the best education company in tech. While others try to shrink the learning experience into the technology, we use technology to expand what is possible in real classrooms with real students and teachers.
@@ -62,20 +63,20 @@ Then make the following edits to your serverless.yaml file:
 plugins:
   - serverless-vpc-discovery
 
-# required config
+# (Optional) in case functions vpcDiscovery specified
 custom:
   vpcDiscovery:
     vpcName: '${opt:env}'
     subnetNames: # optional if securityGroupNames are specified
-      - '${opt:env}_NAME OF SUBNET'
+      - '${opt:env}_<name of subnet>'
     securityGroupNames: # optional if subnetNames are specified
-      - '${opt:env}_NAME OF SECURITY GROUP'
+      - '${opt:env}_<name of security group>'
 
 # (Optional) set a config for the specific function
 functions:
   example1:
     handler: handler.example
-    # inherit basic config
+    # inherit `custom.vpcDiscovery` config if specified or none
   example2:
     handler: handler.example
     # skip vpc configuration
@@ -86,20 +87,20 @@ functions:
     vpcDiscovery:
       vpcName: '${opt:env}'
       securityGroupNames:
-        - '${opt:env}_NAME OF SECURITY GROUP'
+        - '${opt:env}_<name of security group>'
   example4:
     handler: handler.example
     # override basic subnet names and security group names
     vpcDiscovery:
       vpcName: '${opt:env}'
       subnetNames: # optional if securityGroupNames are specified
-        - '${opt:env}_NAME OF SUBNET'
+        - '${opt:env}_<name of subnet>'
       securityGroupNames:  # optional if subnetNames are specified
-        - '${opt:env}_NAME OF SECURITY GROUP'        
+        - '${opt:env}_<name of security group>'        
 ```
-> NOTE: The naming pattern we used here was building off the vpc name for the subnet and security group by extending it with the the subnet and security group name. This makes it easier to switch to different vpcs by changing the environment variable in the command line
- 
-> NOTE: The core sls `provider.vpc` config will change the plugin behavior.
+> NOTE: The core serverless `provider.vpc` will inherit or extended functions vpc config after the plugin apply.
+
+> NOTE: The naming pattern we used here was building off the vpc name for the subnet and security group by extending it with the the subnet and security group name. This makes it easier to switch to different vpcs by changing the environment variable in the command line.
 
 ## Running Tests
 To run the test:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ custom:
 functions:
   example1:
     handler: handler.example
-    # inherit `custom.vpcDiscovery` config if specified or none
+    # inherit `custom.vpcDiscovery` config if specified
   example2:
     handler: handler.example
     # skip vpc configuration

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ vpc:
 ```
 For each lambda function.
       
-> Note: The plugin can be used with the core serverless vpc config. Take a look at [official documentation](https://www.serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration). 
+> Note: The core serverless `provider.vpc` settings will be used, if they are set, instead of `vpcDiscovery`. You can use also mix settings. For example you may set `provider.vpc.subnetIds` while using `vpcDiscovery` to set the `securityGroupIds`. Take a look at [official documentation](https://www.serverless.com/framework/docs/providers/aws/guide/functions#vpc-configuration). 
 
 # About Amplify
 Amplify builds innovative and compelling digital educational products that empower teachers and students across the country. We have a long history as the leading innovator in K-12 education - and have been described as the best tech company in education and the best education company in tech. While others try to shrink the learning experience into the technology, we use technology to expand what is possible in real classrooms with real students and teachers.
@@ -63,7 +63,7 @@ Then make the following edits to your serverless.yaml file:
 plugins:
   - serverless-vpc-discovery
 
-# (Optional) in case functions vpcDiscovery specified
+# Optional: Either set `custom.vpcDiscovery` or `functions.<function name>.vpcDiscovery`
 custom:
   vpcDiscovery:
     vpcName: '${opt:env}'
@@ -83,7 +83,7 @@ functions:
     vpcDiscovery: false
   example3:
     handler: handler.example
-    # inherit basic subnet names and override basic security group names
+    # inherit `custom.vpcDiscovery` and override security group names
     vpcDiscovery:
       vpcName: '${opt:env}'
       securityGroupNames:
@@ -98,8 +98,6 @@ functions:
       securityGroupNames:  # optional if subnetNames are specified
         - '${opt:env}_<name of security group>'        
 ```
-> NOTE: The core serverless `provider.vpc` will inherit or extended functions vpc config after the plugin apply.
-
 > NOTE: The naming pattern we used here was building off the vpc name for the subnet and security group by extending it with the the subnet and security group name. This makes it easier to switch to different vpcs by changing the environment variable in the command line.
 
 ## Running Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-discovery",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -503,84 +503,6 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
       "dev": true
     },
-    "@serverless/cli": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.5.2.tgz",
-      "integrity": "sha512-FMACx0qPD6Uj8U+7jDmAxEe1tdF9DsuY5VsG45nvZ3olC9xYJe/PMwxWsjXfK3tg1HUNywYAGCsy7p5fdXhNzw==",
-      "dev": true,
-      "requires": {
-        "@serverless/core": "^1.1.2",
-        "@serverless/template": "^1.1.3",
-        "@serverless/utils": "^1.2.0",
-        "ansi-escapes": "^4.3.1",
-        "chalk": "^2.4.2",
-        "chokidar": "^3.4.1",
-        "dotenv": "^8.2.0",
-        "figures": "^3.2.0",
-        "minimist": "^1.2.5",
-        "prettyoutput": "^1.2.0",
-        "strip-ansi": "^5.2.0"
-      },
-      "dependencies": {
-        "@serverless/utils": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-1.2.0.tgz",
-          "integrity": "sha512-aI/cpGVUhWbJUR8QDMtPue28EU4ViG/L4/XKuZDfAN2uNQv3NRjwEFIBi/cxyfQnMTYVtMLe9wDjuwzOT4ENzA==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1",
-            "lodash": "^4.17.15",
-            "rc": "^1.2.8",
-            "type": "^2.0.0",
-            "uuid": "^3.4.0",
-            "write-file-atomic": "^2.4.3"
-          }
-        },
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        }
-      }
-    },
     "@serverless/component-metrics": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@serverless/component-metrics/-/component-metrics-1.0.8.tgz",
@@ -589,6 +511,73 @@
       "requires": {
         "node-fetch": "^2.6.0",
         "shortid": "^2.2.14"
+      }
+    },
+    "@serverless/components": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.4.2.tgz",
+      "integrity": "sha512-yBQwN4Z0LqsYzA+SCTh6/LaGEPAu6lNAr32j2pjjZWCnDwpV1TKaSCNDTAPNSVk5L2/8exRpiEQUNM0NyTGWqA==",
+      "dev": true,
+      "requires": {
+        "@serverless/platform-client": "^3.1.1",
+        "@serverless/platform-client-china": "^2.0.9",
+        "@serverless/platform-sdk": "^2.3.2",
+        "@serverless/utils": "^2.0.0",
+        "adm-zip": "^0.4.16",
+        "ansi-escapes": "^4.3.1",
+        "aws4": "^1.10.1",
+        "chalk": "^4.1.0",
+        "child-process-ext": "^2.1.1",
+        "chokidar": "^3.4.2",
+        "dotenv": "^8.2.0",
+        "figures": "^3.2.0",
+        "fs-extra": "^9.0.1",
+        "globby": "^11.0.1",
+        "got": "^11.7.0",
+        "graphlib": "^2.1.8",
+        "https-proxy-agent": "^5.0.0",
+        "ini": "^1.3.5",
+        "inquirer-autocomplete-prompt": "^1.1.0",
+        "js-yaml": "^3.14.0",
+        "memoizee": "^0.4.14",
+        "minimist": "^1.2.5",
+        "moment": "^2.29.0",
+        "open": "^7.2.1",
+        "prettyoutput": "^1.2.0",
+        "ramda": "^0.27.1",
+        "semver": "^7.3.2",
+        "strip-ansi": "^6.0.0",
+        "traverse": "^0.6.6",
+        "uuid": "^8.3.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ramda": {
+          "version": "0.27.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+          "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
+          "dev": true
+        }
       }
     },
     "@serverless/core": {
@@ -691,12 +680,12 @@
       }
     },
     "@serverless/platform-client-china": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.0.8.tgz",
-      "integrity": "sha512-20sceKHkGP56HnwMgrdHwD963bxew63+hE2aNrcu1DtLuUqcRvP5evaWO/CwMDTajJJDhEwi3wQDxPpxtKlJ7A==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@serverless/platform-client-china/-/platform-client-china-2.0.9.tgz",
+      "integrity": "sha512-qec3a5lVaMH0nccgjVgvcEF8M+M95BXZbbYDGypVHEieJQxrKqj057+VVKsiHBeHYXzr4B3v6pIyQHst40vpIw==",
       "dev": true,
       "requires": {
-        "@serverless/utils-china": "^1.0.7",
+        "@serverless/utils-china": "^1.0.11",
         "archiver": "^5.0.2",
         "dotenv": "^8.2.0",
         "fs-extra": "^9.0.1",
@@ -836,9 +825,9 @@
       }
     },
     "@serverless/utils-china": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.0.10.tgz",
-      "integrity": "sha512-pMl6uW672Tll5rjFAYILxu1EwxSaWBE7r/Tr38sCgDOh0t36sRXiI3oCBHIu/C0tqKFfU1s+coRZbZYKkirCiw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@serverless/utils-china/-/utils-china-1.0.11.tgz",
+      "integrity": "sha512-raOPIoPSTrkWKBDuozkYWvLXP2W65K9Uk4ud+lPcbhhBSamO3uVW40nuAkC19MdIoAsFi5oTGYpcc9UDx8b+lg==",
       "dev": true,
       "requires": {
         "@tencent-sdk/capi": "^1.1.2",
@@ -984,15 +973,15 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
-      "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.4.tgz",
+      "integrity": "sha512-M4BwiTJjHmLq6kjON7ZoI2JMlBvpY3BYSdiP6s/qCT3jb1s9/DeJF0JELpAxiVSIxXDzfNKe+r7yedMIoLbknQ==",
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.7.tgz",
-      "integrity": "sha512-Zw1vhUSQZYw+7u5dAwNbIA9TuTotpzY/OF7sJM9FqPOF3SPjKnxrjoTktXDZgUjybf4cWVBP7O8wvKdSaGHweg==",
+      "version": "14.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+      "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
       "dev": true
     },
     "@types/request": {
@@ -1032,70 +1021,142 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.7.0.tgz",
-      "integrity": "sha512-li9aiSVBBd7kU5VlQlT1AqP0uWGDK6JYKUQ9cVDnOg34VNnd9t4jr0Yqc/bKxJr/tDCPDaB4KzoSFN9fgVxe/Q==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.8.2.tgz",
+      "integrity": "sha512-gQ06QLV5l1DtvYtqOyFLXD9PdcILYqlrJj2l+CGDlPtmgLUzc1GpqciJFIRvyfvgLALpnxYINFuw+n9AZhPBKQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.7.0",
-        "@typescript-eslint/scope-manager": "4.7.0",
+        "@typescript-eslint/experimental-utils": "4.8.2",
+        "@typescript-eslint/scope-manager": "4.8.2",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.8.2.tgz",
+          "integrity": "sha512-qHQ8ODi7mMin4Sq2eh/6eu03uVzsf5TX+J43xRmiq8ujng7ViQSHNPLOHGw/Wr5dFEoxq/ubKhzClIIdQy5q3g==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.8.2",
+            "@typescript-eslint/visitor-keys": "4.8.2"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.8.2.tgz",
+          "integrity": "sha512-z1/AVcVF8ju5ObaHe2fOpZYEQrwHyZ7PTOlmjd3EoFeX9sv7UekQhfrCmgUO7PruLNfSHrJGQvrW3Q7xQ8EoAw==",
+          "dev": true
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.2.tgz",
+          "integrity": "sha512-Vg+/SJTMZJEKKGHW7YC21QxgKJrSbxoYYd3MEUGtW7zuytHuEcksewq0DUmo4eh/CTNrVJGSdIY9AtRb6riWFw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.8.2",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.7.0.tgz",
-      "integrity": "sha512-cymzovXAiD4EF+YoHAB5Oh02MpnXjvyaOb+v+BdpY7lsJXZQN34oIETeUwVT2XfV9rSNpXaIcknDLfupO/tUoA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.2.tgz",
+      "integrity": "sha512-hpTw6o6IhBZEsQsjuw/4RWmceRyESfAiEzAEnXHKG1X7S5DXFaZ4IO1JO7CW1aQ604leQBzjZmuMI9QBCAJX8Q==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.7.0",
-        "@typescript-eslint/types": "4.7.0",
-        "@typescript-eslint/typescript-estree": "4.7.0",
+        "@typescript-eslint/scope-manager": "4.8.2",
+        "@typescript-eslint/types": "4.8.2",
+        "@typescript-eslint/typescript-estree": "4.8.2",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/scope-manager": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.8.2.tgz",
+          "integrity": "sha512-qHQ8ODi7mMin4Sq2eh/6eu03uVzsf5TX+J43xRmiq8ujng7ViQSHNPLOHGw/Wr5dFEoxq/ubKhzClIIdQy5q3g==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.8.2",
+            "@typescript-eslint/visitor-keys": "4.8.2"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.8.2.tgz",
+          "integrity": "sha512-z1/AVcVF8ju5ObaHe2fOpZYEQrwHyZ7PTOlmjd3EoFeX9sv7UekQhfrCmgUO7PruLNfSHrJGQvrW3Q7xQ8EoAw==",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.2.tgz",
+          "integrity": "sha512-HToGNwI6fekH0dOw3XEVESUm71Onfam0AKin6f26S2FtUmO7o3cLlWgrIaT1q3vjB3wCTdww3Dx2iGq5wtUOCg==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.8.2",
+            "@typescript-eslint/visitor-keys": "4.8.2",
+            "debug": "^4.1.1",
+            "globby": "^11.0.1",
+            "is-glob": "^4.0.1",
+            "lodash": "^4.17.15",
+            "semver": "^7.3.2",
+            "tsutils": "^3.17.1"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.2.tgz",
+          "integrity": "sha512-Vg+/SJTMZJEKKGHW7YC21QxgKJrSbxoYYd3MEUGtW7zuytHuEcksewq0DUmo4eh/CTNrVJGSdIY9AtRb6riWFw==",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "4.8.2",
+            "eslint-visitor-keys": "^2.0.0"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.7.0.tgz",
-      "integrity": "sha512-+meGV8bMP1sJHBI2AFq1GeTwofcGiur8LoIr6v+rEmD9knyCqDlrQcFHR0KDDfldHIFDU/enZ53fla6ReF4wRw==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.8.2.tgz",
+      "integrity": "sha512-u0leyJqmclYr3KcXOqd2fmx6SDGBO0MUNHHAjr0JS4Crbb3C3d8dwAdlazy133PLCcPn+aOUFiHn72wcuc5wYw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.7.0",
-        "@typescript-eslint/types": "4.7.0",
-        "@typescript-eslint/typescript-estree": "4.7.0",
+        "@typescript-eslint/scope-manager": "4.8.2",
+        "@typescript-eslint/types": "4.8.2",
+        "@typescript-eslint/typescript-estree": "4.8.2",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.7.0.tgz",
-      "integrity": "sha512-ILITvqwDJYbcDCROj6+Ob0oCKNg3SH46iWcNcTIT9B5aiVssoTYkhKjxOMNzR1F7WSJkik4zmuqve5MdnA0DyA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.8.2.tgz",
+      "integrity": "sha512-qHQ8ODi7mMin4Sq2eh/6eu03uVzsf5TX+J43xRmiq8ujng7ViQSHNPLOHGw/Wr5dFEoxq/ubKhzClIIdQy5q3g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.7.0",
-        "@typescript-eslint/visitor-keys": "4.7.0"
+        "@typescript-eslint/types": "4.8.2",
+        "@typescript-eslint/visitor-keys": "4.8.2"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.7.0.tgz",
-      "integrity": "sha512-uLszFe0wExJc+I7q0Z/+BnP7wao/kzX0hB5vJn4LIgrfrMLgnB2UXoReV19lkJQS1a1mHWGGODSxnBx6JQC3Sg==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.8.2.tgz",
+      "integrity": "sha512-z1/AVcVF8ju5ObaHe2fOpZYEQrwHyZ7PTOlmjd3EoFeX9sv7UekQhfrCmgUO7PruLNfSHrJGQvrW3Q7xQ8EoAw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.7.0.tgz",
-      "integrity": "sha512-5XZRQznD1MfUmxu1t8/j2Af4OxbA7EFU2rbo0No7meb46eHgGkSieFdfV6omiC/DGIBhH9H9gXn7okBbVOm8jw==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.2.tgz",
+      "integrity": "sha512-HToGNwI6fekH0dOw3XEVESUm71Onfam0AKin6f26S2FtUmO7o3cLlWgrIaT1q3vjB3wCTdww3Dx2iGq5wtUOCg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.7.0",
-        "@typescript-eslint/visitor-keys": "4.7.0",
+        "@typescript-eslint/types": "4.8.2",
+        "@typescript-eslint/visitor-keys": "4.8.2",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -1105,12 +1166,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.7.0.tgz",
-      "integrity": "sha512-aDJDWuCRsf1lXOtignlfiPODkzSxxop7D0rZ91L6ZuMlcMCSh0YyK+gAfo5zN/ih6WxMwhoXgJWC3cWQdaKC+A==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.2.tgz",
+      "integrity": "sha512-Vg+/SJTMZJEKKGHW7YC21QxgKJrSbxoYYd3MEUGtW7zuytHuEcksewq0DUmo4eh/CTNrVJGSdIY9AtRb6riWFw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.7.0",
+        "@typescript-eslint/types": "4.8.2",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -1329,9 +1390,9 @@
       }
     },
     "archiver": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.0.2.tgz",
-      "integrity": "sha512-Tq3yV/T4wxBsD2Wign8W9VQKhaUxzzRmjEiSoOK0SLqPgDP/N1TKdYyBeIEu56T4I9iO4fKTTR0mN9NWkBA0sg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.1.0.tgz",
+      "integrity": "sha512-iKuQUP1nuKzBC2PFlGet5twENzCfyODmvkxwDV0cEFXavwcLrIW5ssTuHi9dyTPvpWr6Faweo2eQaQiLIwyXTA==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
@@ -1340,7 +1401,7 @@
         "readable-stream": "^3.6.0",
         "readdir-glob": "^1.0.0",
         "tar-stream": "^2.1.4",
-        "zip-stream": "^4.0.0"
+        "zip-stream": "^4.0.4"
       }
     },
     "archiver-utils": {
@@ -1559,9 +1620,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.788.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.788.0.tgz",
-      "integrity": "sha512-UKc+4MFRezIkgk668mylj7MpVD2dCtiDBppgx05SwYSDGT60bixrKv3nE/YJK+gAv53CWVf7WL6hNv76+TWkTA==",
+      "version": "2.799.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.799.0.tgz",
+      "integrity": "sha512-NYAoiNU+bJXhlJsC0rFqrmD5t5ho7/VxldmziP6HLPYHfOCI9Uvk6UVjfPmhLWPm0mHnIxhsHqmsNGyjhHNYmw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -1637,9 +1698,9 @@
       "dev": true
     },
     "base64-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -2368,13 +2429,13 @@
       "dev": true
     },
     "compress-commons": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.1.tgz",
-      "integrity": "sha512-xZm9o6iikekkI0GnXCmAl3LQGZj5TBDj0zLowsqi7tJtEa3FMGSEcHcqrSJIrOAk1UG/NBbDn/F1q+MG/p/EsA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.0.2.tgz",
+      "integrity": "sha512-qhd32a9xgzmpfoga1VQEiLEwdKZ6Plnpx5UCgIsf89FSolyJ7WnifY4Gtjgv5WR6hWAyRaHxC5MiEhU/38U70A==",
       "dev": true,
       "requires": {
         "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.0",
+        "crc32-stream": "^4.0.1",
         "normalize-path": "^3.0.0",
         "readable-stream": "^3.6.0"
       }
@@ -2456,34 +2517,23 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
       "dev": true,
       "requires": {
-        "buffer": "^5.1.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        }
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
       }
     },
     "crc32-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.0.tgz",
-      "integrity": "sha512-tyMw2IeUX6t9jhgXI6um0eKfWq4EIDpfv5m7GX4Jzp7eVelQ360xd8EPXJhp2mHwLQIkqlnMLjzqSZI3a+0wRw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.1.tgz",
+      "integrity": "sha512-FN5V+weeO/8JaXsamelVYO1PHyeCsuL3HcG4cqsj0ceARcocxalaShCsohZMSAF+db7UYFwBy1rARK/0oFItUw==",
       "dev": true,
       "requires": {
-        "crc": "^3.4.4",
+        "crc-32": "^1.2.0",
         "readable-stream": "^3.4.0"
       }
     },
@@ -3330,9 +3380,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.13.0.tgz",
-      "integrity": "sha512-uCORMuOO8tUzJmsdRtrvcGq5qposf7Rw0LwkTJkoDbOycVQtQjmnhZSuLQnozLE4TmAzlMVV45eCHmQ1OpDKUQ==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.14.0.tgz",
+      "integrity": "sha512-5YubdnPXrlrYAFCKybPuHIAH++PINe1pmKNc5wQRB9HSbqIK1ywAnntE3Wwua4giKu0bjligf1gLF6qxMGOYRA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3420,9 +3470,9 @@
       }
     },
     "eslint-config-standard": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.1.tgz",
-      "integrity": "sha512-WBBiQQZdaPyL+4sPkGWhWrHCDtvJoU195B9j8yXE9uFQnX34gMXI5CeBRm95gx3PMEZPM5OpwET10hH4F4SxCA==",
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.2.tgz",
+      "integrity": "sha512-fx3f1rJDsl9bY7qzyX8SAtP8GBSk6MfXFaTfaGgk12aAYW4gJSyRm7dM790L6cbXv63fvjY4XeSzXnb4WM+SKw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -3754,6 +3804,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "dev": true
     },
     "expand-template": {
       "version": "2.0.3",
@@ -4215,18 +4271,18 @@
       "dev": true
     },
     "fs2": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/fs2/-/fs2-0.3.8.tgz",
-      "integrity": "sha512-HxOTRiFS3PqwAOmlp1mTwLA+xhQBdaP82b5aBamc/rHKFVyn4qL8YpngaAleD52PNMzBm6TsGOoU/Hq+bAfBhA==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/fs2/-/fs2-0.3.9.tgz",
+      "integrity": "sha512-WsOqncODWRlkjwll+73bAxVW3JPChDgaPX3DT4iTTm73UmG4VgALa7LaFblP232/DN60itkOrPZ8kaP1feksGQ==",
       "dev": true,
       "requires": {
         "d": "^1.0.1",
         "deferred": "^0.7.11",
         "es5-ext": "^0.10.53",
         "event-emitter": "^0.3.5",
-        "ignore": "^5.1.4",
+        "ignore": "^5.1.8",
         "memoizee": "^0.4.14",
-        "type": "^2.0.0"
+        "type": "^2.1.0"
       }
     },
     "fsevents": {
@@ -6055,9 +6111,9 @@
       }
     },
     "node-abi": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
-      "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
+      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -6843,6 +6899,12 @@
         "lodash": "4.17.x"
       }
     },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6882,9 +6944,9 @@
       }
     },
     "protobufjs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
-      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+      "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
       "dev": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -6903,9 +6965,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.30",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.30.tgz",
-          "integrity": "sha512-HmqFpNzp3TSELxU/bUuRK+xzarVOAsR00hzcvM0TXrMlt/+wcSLa5q6YhTb6/cA6wqDCZLDcfd8fSL95x5h7AA==",
+          "version": "13.13.33",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.33.tgz",
+          "integrity": "sha512-1B3GM1yuYsFyEvBb+ljBqWBOylsWDYioZ5wpu8AhXdIhq20neXS7eaSC8GkwHE0yQYGiOIV43lMsgRYTgKZefQ==",
           "dev": true
         },
         "long": {
@@ -7344,27 +7406,28 @@
       }
     },
     "serverless": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.11.1.tgz",
-      "integrity": "sha512-BQN53zkm/HWh+QtzaR/uXHRAxAcabHkstyRMo4+9JJc+DM7cQM9cyRBm15BW9PKMO9c3aCKYNTJSb5cegn7qmw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-2.13.0.tgz",
+      "integrity": "sha512-MOz0JYlPrWGwuyVUIncyaNRSlwOzVUFj5T/ITRjtO5PYXUWr+BB+yhZ97KoOhuL/hVnQ7ZjsmYgOvzo8hHwv9w==",
       "dev": true,
       "requires": {
         "@serverless/cli": "^1.5.2",
-        "@serverless/components": "^3.3.0",
+        "@serverless/components": "^3.4.2",
         "@serverless/enterprise-plugin": "^4.1.2",
         "@serverless/utils": "^2.0.0",
         "ajv": "^6.12.6",
         "ajv-keywords": "^3.5.2",
-        "archiver": "^5.0.2",
-        "aws-sdk": "^2.787.0",
+        "archiver": "^5.1.0",
+        "aws-sdk": "^2.799.0",
         "bluebird": "^3.7.2",
         "boxen": "^4.2.0",
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "child-process-ext": "^2.1.1",
         "d": "^1.0.1",
-        "dayjs": "^1.9.5",
+        "dayjs": "^1.9.6",
         "decompress": "^4.2.1",
+        "dotenv": "^8.2.0",
         "download": "^8.0.0",
         "essentials": "^1.1.1",
         "fastest-levenshtein": "^1.0.12",
@@ -7386,7 +7449,7 @@
         "ncjsm": "^4.1.0",
         "node-fetch": "^2.6.1",
         "object-hash": "^2.0.3",
-        "p-limit": "^3.0.2",
+        "p-limit": "^3.1.0",
         "promise-queue": "^2.2.5",
         "replaceall": "^0.1.6",
         "semver": "^7.3.2",
@@ -7401,77 +7464,80 @@
         "yargs-parser": "^20.2.4"
       },
       "dependencies": {
-        "@serverless/components": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@serverless/components/-/components-3.3.0.tgz",
-          "integrity": "sha512-QEjWK9jsIXMh9j/my8HJDtS04bL0TtiLPIr50jfPMUkqnl51thZGHswNwkkuCsmnvcQhZGspD68hIqWPlQRjMw==",
+        "@serverless/cli": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@serverless/cli/-/cli-1.5.2.tgz",
+          "integrity": "sha512-FMACx0qPD6Uj8U+7jDmAxEe1tdF9DsuY5VsG45nvZ3olC9xYJe/PMwxWsjXfK3tg1HUNywYAGCsy7p5fdXhNzw==",
           "dev": true,
           "requires": {
-            "@serverless/platform-client": "^3.1.1",
-            "@serverless/platform-client-china": "^2.0.4",
-            "@serverless/platform-sdk": "^2.3.2",
-            "@serverless/utils": "^2.0.0",
-            "adm-zip": "^0.4.16",
+            "@serverless/core": "^1.1.2",
+            "@serverless/template": "^1.1.3",
+            "@serverless/utils": "^1.2.0",
             "ansi-escapes": "^4.3.1",
-            "aws4": "^1.10.1",
-            "chalk": "^4.1.0",
-            "child-process-ext": "^2.1.1",
-            "chokidar": "^3.4.2",
+            "chalk": "^2.4.2",
+            "chokidar": "^3.4.1",
             "dotenv": "^8.2.0",
             "figures": "^3.2.0",
-            "fs-extra": "^9.0.1",
-            "globby": "^11.0.1",
-            "got": "^11.7.0",
-            "graphlib": "^2.1.8",
-            "https-proxy-agent": "^5.0.0",
-            "ini": "^1.3.5",
-            "inquirer-autocomplete-prompt": "^1.1.0",
-            "js-yaml": "^3.14.0",
             "minimist": "^1.2.5",
-            "moment": "^2.29.0",
-            "open": "^7.2.1",
             "prettyoutput": "^1.2.0",
-            "ramda": "^0.27.1",
-            "semver": "^7.3.2",
-            "strip-ansi": "^6.0.0",
-            "traverse": "^0.6.6",
-            "uuid": "^8.3.1"
+            "strip-ansi": "^5.2.0"
+          },
+          "dependencies": {
+            "@serverless/utils": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/@serverless/utils/-/utils-1.2.0.tgz",
+              "integrity": "sha512-aI/cpGVUhWbJUR8QDMtPue28EU4ViG/L4/XKuZDfAN2uNQv3NRjwEFIBi/cxyfQnMTYVtMLe9wDjuwzOT4ENzA==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.0.1",
+                "lodash": "^4.17.15",
+                "rc": "^1.2.8",
+                "type": "^2.0.0",
+                "uuid": "^3.4.0",
+                "write-file-atomic": "^2.4.3"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+              "dev": true
+            }
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "p-limit": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
-          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "yocto-queue": "^0.1.0"
           }
         },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "ramda": {
-          "version": "0.27.1",
-          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-          "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
-          "dev": true
-        },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^4.1.0"
           }
         },
         "uuid": {
@@ -7479,6 +7545,17 @@
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
           "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
           "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
         },
         "yargs-parser": {
           "version": "20.2.4",
@@ -7601,14 +7678,25 @@
       }
     },
     "simple-git": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.21.0.tgz",
-      "integrity": "sha512-rohCHmEjD/ESXFLxF4bVeqgdb4Awc65ZyyuCKl3f7BvgMbZOBa/Ye3HN/GFnvruiUOAWWNupxhz3Rz5/3vJLTg==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.23.0.tgz",
+      "integrity": "sha512-s/gEkxFV2WGTN4kO1uQoA4cE4rq0FRzQPR5Yhgg8JUuA4IhOeccjlKSFhwF3rrpo7797ZvQc7L6hJJNA4szHCw==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
         "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.1.1"
+        "debug": "^4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        }
       }
     },
     "simple-swizzle": {
@@ -8116,9 +8204,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -8716,9 +8804,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
-      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
       "dev": true
     },
     "unbzip2-stream": {
@@ -9323,14 +9411,20 @@
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
+    },
     "zip-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.2.tgz",
-      "integrity": "sha512-TGxB2g+1ur6MHkvM644DuZr8Uzyz0k0OYWtS3YlpfWBEmK4woaC2t3+pozEL3dBfIPmpgmClR5B2QRcMgGt22g==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.0.4.tgz",
+      "integrity": "sha512-a65wQ3h5gcQ/nQGWV1mSZCEzCML6EK/vyVPcrPNynySP1j3VBbQKh3nhC8CbORb+jfl2vXvh56Ul5odP1bAHqw==",
       "dev": true,
       "requires": {
         "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.0.0",
+        "compress-commons": "^4.0.2",
         "readable-stream": "^3.6.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-discovery",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "engines": {
     "node": ">=4.0"
   },
@@ -48,16 +48,16 @@
     ]
   },
   "devDependencies": {
-    "@types/mocha": "^8.0.3",
-    "@types/node": "^14.14.7",
-    "@typescript-eslint/eslint-plugin": "^4.7.0",
-    "@typescript-eslint/parser": "^4.7.0",
+    "@types/mocha": "^8.0.4",
+    "@types/node": "^14.14.10",
+    "@typescript-eslint/eslint-plugin": "^4.8.2",
+    "@typescript-eslint/parser": "^4.8.2",
     "aws-sdk-mock": "^5.1.0",
     "chai": "^4.2.0",
     "chai-spies": "^1.0.0",
-    "eslint": "^7.13.0",
+    "eslint": "^7.14.0",
     "eslint-config-airbnb": "^18.2.1",
-    "eslint-config-standard": "^16.0.1",
+    "eslint-config-standard": "^16.0.2",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-node": "^11.1.0",
@@ -69,12 +69,12 @@
     "mocha-param": "^2.0.1",
     "nyc": "^15.1.0",
     "randomstring": "^1.1.5",
-    "serverless": "^2.11.1",
+    "serverless": "^2.13.0",
     "shelljs": "^0.8.4",
     "ts-node": "^9.0.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.1.2"
   },
   "dependencies": {
-    "aws-sdk": "^2.788.0"
+    "aws-sdk": "^2.799.0"
   }
 }

--- a/src/common/lambda-function.ts
+++ b/src/common/lambda-function.ts
@@ -19,7 +19,7 @@ export class LambdaFunction {
   public async getFuncVPC (funcName: string, funcVPCDiscovery: FuncVPCDiscovery): Promise<VPC> {
     if (typeof funcVPCDiscovery === "boolean" && !funcVPCDiscovery) {
       // skip vpc setup for `vpcDiscovery=false` option
-      Globals.logInfo(`Skip the VPC config for function '${funcName}'`);
+      Globals.logInfo(`Skipping VPC config for the function '${funcName}'`);
       return null;
     }
     // inherit the `custom.vpcDiscovery`
@@ -33,7 +33,7 @@ export class LambdaFunction {
     if (!isConfigValid) {
       // skip vpc setup for not valid config
       Globals.logWarning(
-        `The function '${funcName}' is not configured correctly. Skip the VPC config.` +
+        `The function '${funcName}' is not configured correctly. VPC not configured.` +
         "Please see the README for the proper setup."
       );
       return null;

--- a/src/common/lambda-function.ts
+++ b/src/common/lambda-function.ts
@@ -19,10 +19,10 @@ export class LambdaFunction {
   public async getFuncVPC (funcName: string, funcVPCDiscovery: FuncVPCDiscovery): Promise<VPC> {
     if (typeof funcVPCDiscovery === "boolean" && !funcVPCDiscovery) {
       // skip vpc setup for `vpcDiscovery=false` option
-      Globals.logInfo(`Skip the VPC config for the function '${funcName}'`);
+      Globals.logInfo(`Skip the VPC config for function '${funcName}'`);
       return null;
     }
-    // inherit basic config
+    // inherit the `custom.vpcDiscovery`
     const vpcDiscovery = Object.assign({}, this.basicVPCDiscovery, funcVPCDiscovery);
     // return null in case vpcDiscovery not setup
     if (isObjectEmpty(vpcDiscovery)) {

--- a/src/common/lambda-function.ts
+++ b/src/common/lambda-function.ts
@@ -39,7 +39,7 @@ export class LambdaFunction {
       return null;
     }
 
-    return await this.ec2Wrapper.getVpcConfig(this.basicVPCDiscovery);
+    return await this.ec2Wrapper.getVpcConfig(vpcDiscovery);
   }
 
   /**

--- a/src/common/lambda-function.ts
+++ b/src/common/lambda-function.ts
@@ -29,7 +29,7 @@ export class LambdaFunction {
       return null;
     }
     // validate vpcDiscovery config
-    const isConfigValid = this.validateVPCDiscovery(vpcDiscovery);
+    const isConfigValid = this.validateFuncVPCDiscoveryConfig(vpcDiscovery);
     if (!isConfigValid) {
       // skip vpc setup for not valid config
       Globals.logWarning(
@@ -46,7 +46,7 @@ export class LambdaFunction {
    * Validate function vpc discovery config
    * @returns {boolean}
    */
-  public validateVPCDiscovery (funcVPCDiscovery: FuncVPCDiscovery): boolean {
+  public validateFuncVPCDiscoveryConfig (funcVPCDiscovery: FuncVPCDiscovery): boolean {
     if (funcVPCDiscovery) {
       // check is vpcDiscovery correct
       const isSubnetsOrGroups = funcVPCDiscovery.subnetNames != null || funcVPCDiscovery.securityGroupNames != null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ class VPCPlugin {
    * @param lifecycleFunc lifecycle function that actually does desired action
    */
   public async hookWrapper (lifecycleFunc: any) {
-    this.validateCustomVPCDiscovery();
+    this.validateCustomVPCDiscoveryConfig();
     this.initResources();
     return await lifecycleFunc.call(this);
   }
@@ -33,7 +33,7 @@ class VPCPlugin {
   /**
    * Validate if the plugin config exists
    */
-  public validateCustomVPCDiscovery (): void {
+  public validateCustomVPCDiscoveryConfig (): void {
     const config = this.serverless.service.custom;
     if (config && !config.vpcDiscovery && config.vpc) {
       config.vpcDiscovery = config.vpc;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ class VPCPlugin {
    * @param lifecycleFunc lifecycle function that actually does desired action
    */
   public async hookWrapper (lifecycleFunc: any) {
-    this.validateConfigExists();
+    this.validateCustomVPCDiscovery();
     this.initResources();
     return await lifecycleFunc.call(this);
   }
@@ -33,20 +33,20 @@ class VPCPlugin {
   /**
    * Validate if the plugin config exists
    */
-  public validateConfigExists (): void {
+  public validateCustomVPCDiscovery (): void {
     const config = this.serverless.service.custom;
-    if (config && !config.vpcDiscovery) {
+    if (config && !config.vpcDiscovery && config.vpc) {
       config.vpcDiscovery = config.vpc;
       Globals.logWarning(
         "The `vpc` option of `custom` config is deprecated and will be removed in the future. " +
-        "Please use `vpcDiscovery` option instead."
+        "Please use the `vpcDiscovery` option instead."
       );
     }
     const vpc = config && config.vpcDiscovery;
-    // Checks if the serverless file is setup correctly
-    if (!vpc || vpc.vpcName == null || (vpc.subnetNames == null && vpc.securityGroupNames == null)) {
+    // Checking the vpcDiscovery config is setup correctly if exists
+    if (vpc && (vpc.vpcName == null || (vpc.subnetNames == null && vpc.securityGroupNames == null))) {
       throw new Error(
-        "Serverless file is not configured correctly. " +
+        "The `custom.vpcDiscovery` is not configured correctly. " +
         "You must specify the vpcName and at least one of subnetNames or securityGroupNames. " +
         "Please see README for proper setup."
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,9 @@ class VPCPlugin {
   public initResources (): void {
     this.awsCredentials = this.serverless.providers.aws.getCredentials();
     this.awsCredentials.region = this.serverless.providers.aws.getRegion();
-    this.lambdaFunction = new LambdaFunction(this.awsCredentials, this.serverless.service.custom.vpcDiscovery);
+
+    const baseVPCDiscovery = this.serverless.service.custom ? this.serverless.service.custom.vpcDiscovery : null;
+    this.lambdaFunction = new LambdaFunction(this.awsCredentials, baseVPCDiscovery);
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,8 +76,13 @@ async function sleep (seconds) {
   return new Promise((resolve) => setTimeout(resolve, 1000 * seconds));
 }
 
+function isObjectEmpty (object: Object): boolean {
+  return Object.keys(object).length === 0;
+}
+
 export {
   sleep,
   getAWSPagedResults,
-  throttledCall
+  throttledCall,
+  isObjectEmpty
 };

--- a/test/integration-tests/basic.test.ts
+++ b/test/integration-tests/basic.test.ts
@@ -18,7 +18,8 @@ const testCases = [
   {
     testDescription: "Basic example",
     testFolder: `${CONFIGS_FOLDER}/basic-example`
-  }, {
+  },
+  {
     testDescription: "No basic VPC config",
     testFolder: `${CONFIGS_FOLDER}/only-functions`
   }
@@ -26,50 +27,53 @@ const testCases = [
 
 describe("Integration Tests", function () {
   this.timeout(TIMEOUT_MINUTES);
+
   // @ts-ignore
   // eslint-disable-next-line no-template-curly-in-string
-  itParam("${value.testDescription}", testCases, async (done, value) => {
+  itParam("${value.testDescription}", testCases, async (value) => {
     const slsConfig = path.join(__dirname, `${value.testFolder}/serverless.yml`);
 
     // read basic vpcDiscovery config
-    const slsBasicVPCConfig = readBasicVPCConfig(slsConfig, TEST_VPC_NAME);
+    const basicVPCDiscovery = readBasicVPCConfig(slsConfig, TEST_VPC_NAME);
     // read lambda func names and func vpc configs from the serverless.yml
     const funcConfigs = readLambdaFunctions(slsConfig, TEST_VPC_NAME, RANDOM_STRING);
+    // prepare folder with npm packages and deploy
+    await execution.createTempDir(TEMP_DIR, value.testFolder);
     try {
-      // prepare folder with npm packages and deploy
-      await execution.createTempDir(TEMP_DIR, value.testFolder);
       await execution.slsDeploy(TEMP_DIR, RANDOM_STRING);
 
+      // eslint-disable-next-line guard-for-in
       for (const funcName in funcConfigs) {
-        const vpcDiscovery = funcConfigs[funcName];
+        const funcVPCDiscovery = funcConfigs[funcName];
         // get lambda function info
         const data = await getLambdaFunctionInfo(funcName);
         const lambdaVPCConfig = data.Configuration.VpcConfig;
 
-        if (typeof vpcDiscovery === "boolean" && !vpcDiscovery) {
+        if (typeof funcVPCDiscovery === "boolean" && !funcVPCDiscovery) {
           // for option `func.vpcDiscovery: false` it shouldn't be vpc config
           expect(lambdaVPCConfig).to.equal(undefined);
         } else {
           // check vpcDiscovery config
-          const vpcConfig = Object.assign({}, slsBasicVPCConfig, vpcDiscovery);
+          const emptyVPCDiscovery = { vpcName: undefined, subnetNames: [], securityGroupNames: [] };
+          const vpcId = lambdaVPCConfig ? lambdaVPCConfig.VpcId : null;
+          const vpcDiscovery = Object.assign({}, emptyVPCDiscovery, basicVPCDiscovery, funcVPCDiscovery);
 
           // get vpc info by lambda vpc id and check names
-          const vpc = await getVPCInfo(lambdaVPCConfig.VpcId);
-          expect(vpcConfig.vpcName).to.equal(vpc.VpcName);
+          const vpc = vpcId ? await getVPCInfo(vpcId) : {};
+          expect(vpcDiscovery.vpcName).to.equal(vpc.VpcName);
 
           // get vpc subnets info by lambda vpc id and subnets ids, check names
-          const subnets = await getSubnetsInfo(lambdaVPCConfig.VpcId, lambdaVPCConfig.SubnetIds);
+          const subnets = vpcId ? await getSubnetsInfo(vpcId, lambdaVPCConfig.SubnetIds) : [];
           const subnetNames = subnets.map((item) => item.SubnetName).sort();
-          expect(JSON.stringify(vpcConfig.subnetNames.sort())).to.equal(JSON.stringify(subnetNames));
+          expect(JSON.stringify(vpcDiscovery.subnetNames.sort())).to.equal(JSON.stringify(subnetNames));
 
           // get vpc security groups info by lambda vpc id and security groups ids, check names
-          const securityGroups = await getSecurityGroupInfo(lambdaVPCConfig.VpcId, lambdaVPCConfig.SecurityGroupIds);
+          const securityGroups = vpcId ? await getSecurityGroupInfo(vpcId, lambdaVPCConfig.SecurityGroupIds) : [];
           const securityGroupNames = securityGroups.map((item) => item.GroupName).sort();
-          expect(JSON.stringify(vpcConfig.securityGroupNames.sort())).to.equal(JSON.stringify(securityGroupNames));
+          expect(JSON.stringify(vpcDiscovery.securityGroupNames.sort())).to.equal(JSON.stringify(securityGroupNames));
         }
       }
     } finally {
-      done();
       await execution.slsRemove(TEMP_DIR, RANDOM_STRING);
     }
   });

--- a/test/integration-tests/basic.test.ts
+++ b/test/integration-tests/basic.test.ts
@@ -14,10 +14,15 @@ const TIMEOUT_MINUTES = 15 * 60 * 1000; // 15 minutes in milliseconds
 const RANDOM_STRING = getRandomString();
 const TEMP_DIR = `~/tmp/vpc-discovery-test-${RANDOM_STRING}`;
 
-const testCases = [{
-  testDescription: "Basic example",
-  testFolder: `${CONFIGS_FOLDER}/basic-example`
-}];
+const testCases = [
+  {
+    testDescription: "Basic example",
+    testFolder: `${CONFIGS_FOLDER}/basic-example`
+  }, {
+    testDescription: "No basic VPC config",
+    testFolder: `${CONFIGS_FOLDER}/only-functions`
+  }
+];
 
 describe("Integration Tests", function () {
   this.timeout(TIMEOUT_MINUTES);

--- a/test/integration-tests/basic.test.ts
+++ b/test/integration-tests/basic.test.ts
@@ -54,8 +54,9 @@ describe("Integration Tests", function () {
           expect(lambdaVPCConfig).to.equal(undefined);
         } else {
           // check vpcDiscovery config
-          const emptyVPCDiscovery = { vpcName: undefined, subnetNames: [], securityGroupNames: [] };
           const vpcId = lambdaVPCConfig ? lambdaVPCConfig.VpcId : null;
+          // inherit basic config if exist else empty for further checks
+          const emptyVPCDiscovery = { vpcName: undefined, subnetNames: [], securityGroupNames: [] };
           const vpcDiscovery = Object.assign({}, emptyVPCDiscovery, basicVPCDiscovery, funcVPCDiscovery);
 
           // get vpc info by lambda vpc id and check names

--- a/test/integration-tests/basic/only-functions/handler.ts
+++ b/test/integration-tests/basic/only-functions/handler.ts
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports.helloWorld = (event, context, callback) => {
+  const response = {
+    statusCode: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*" // Required for CORS support to work
+    },
+    body: JSON.stringify({
+      message: "Go Serverless VPC Discovery! Your function executed successfully!",
+      input: event
+    })
+  };
+
+  callback(null, response);
+};

--- a/test/integration-tests/basic/only-functions/serverless.yml
+++ b/test/integration-tests/basic/only-functions/serverless.yml
@@ -1,0 +1,32 @@
+# basic example
+service: test-sls-vpc-dicovery-${opt:RANDOM_STRING}
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  region: us-west-2
+  endpointType: regional
+  stage: test
+
+functions:
+  helloWorld:
+    handler: handler.helloWorld
+    # empty vpc config
+  helloWorld2:
+    handler: handler.helloWorld
+    # subnet ids and security group ids
+    vpcDiscovery:
+      vpcName: ${env:TEST_VPC_NAME}
+      subnetNames:
+        - ${env:TEST_VPC_NAME}_intranet_us-west-2a
+        - ${env:TEST_VPC_NAME}_intranet_us-west-2b
+        - ${env:TEST_VPC_NAME}_intranet_us-west-2c
+      securityGroupNames:
+        - ${env:TEST_VPC_NAME}_maintenance
+
+plugins:
+  - serverless-vpc-discovery
+
+package:
+  exclude:
+    - node_modules/**

--- a/test/integration-tests/basic/only-functions/serverless.yml
+++ b/test/integration-tests/basic/only-functions/serverless.yml
@@ -1,5 +1,5 @@
-# basic example
-service: test-sls-vpc-dicovery-${opt:RANDOM_STRING}
+# only functions setup example
+service: test-sls-only-functions-${opt:RANDOM_STRING}
 
 provider:
   name: aws

--- a/test/integration-tests/utils/common.ts
+++ b/test/integration-tests/utils/common.ts
@@ -37,7 +37,7 @@ function readLambdaFunctions (configPath: string, vpcName: string, identifier: s
  */
 function readBasicVPCConfig (configPath: string, vpcName: string) {
   const config = readYml(configPath);
-  if (!config.custom || config.custom.vpcDiscovery) {
+  if (!config.custom || !config.custom.vpcDiscovery) {
     return null;
   }
   return compileVPCConfig(config.custom.vpcDiscovery, vpcName);

--- a/test/integration-tests/utils/common.ts
+++ b/test/integration-tests/utils/common.ts
@@ -37,8 +37,10 @@ function readLambdaFunctions (configPath: string, vpcName: string, identifier: s
  */
 function readBasicVPCConfig (configPath: string, vpcName: string) {
   const config = readYml(configPath);
-  const vpcDiscovery = config.custom.vpcDiscovery;
-  return compileVPCConfig(vpcDiscovery, vpcName);
+  if (!config.custom || config.custom.vpcDiscovery) {
+    return null;
+  }
+  return compileVPCConfig(config.custom.vpcDiscovery, vpcName);
 }
 
 /**

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -82,7 +82,7 @@ describe("Given a vpc,", () => {
       subnetNames: subnets,
       securityGroupNames: securityGroups
     });
-    plugin.validateCustomVPCDiscovery();
+    plugin.validateCustomVPCDiscoveryConfig();
     plugin.initResources();
 
     const expectedResult = {
@@ -192,7 +192,7 @@ describe("Catching errors in updateVpcConfig ", () => {
       subnetNames: subnets,
       securityGroupNames: securityGroups
     });
-    plugin.validateCustomVPCDiscovery();
+    plugin.validateCustomVPCDiscoveryConfig();
     plugin.initResources();
     return plugin.updateFunctionsVpcConfig().then(() => {
       throw new Error("Test has failed. updateVpcConfig did not catch errors.");
@@ -209,7 +209,7 @@ describe("Catching errors in updateVpcConfig ", () => {
     });
 
     try {
-      plugin.validateCustomVPCDiscovery();
+      plugin.validateCustomVPCDiscoveryConfig();
     } catch (err) {
       const expectedErrorMessage = "The `custom.vpcDiscovery` is not configured correctly. " +
         "You must specify the vpcName and at least one of subnetNames or securityGroupNames. " +

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -82,7 +82,7 @@ describe("Given a vpc,", () => {
       subnetNames: subnets,
       securityGroupNames: securityGroups
     });
-    plugin.validateConfigExists();
+    plugin.validateCustomVPCDiscovery();
     plugin.initResources();
 
     const expectedResult = {
@@ -192,7 +192,7 @@ describe("Catching errors in updateVpcConfig ", () => {
       subnetNames: subnets,
       securityGroupNames: securityGroups
     });
-    plugin.validateConfigExists();
+    plugin.validateCustomVPCDiscovery();
     plugin.initResources();
     return plugin.updateFunctionsVpcConfig().then(() => {
       throw new Error("Test has failed. updateVpcConfig did not catch errors.");
@@ -209,9 +209,9 @@ describe("Catching errors in updateVpcConfig ", () => {
     });
 
     try {
-      plugin.validateConfigExists();
+      plugin.validateCustomVPCDiscovery();
     } catch (err) {
-      const expectedErrorMessage = "Serverless file is not configured correctly. " +
+      const expectedErrorMessage = "The `custom.vpcDiscovery` is not configured correctly. " +
         "You must specify the vpcName and at least one of subnetNames or securityGroupNames. " +
         "Please see README for proper setup.";
       expect(err.message).to.equal(expectedErrorMessage);


### PR DESCRIPTION
Make the `custom.vpcDiscovery` optional. We can specify a `vpc` config just for a function which we need.

```
...
functions:
  example1:
    handler: handler.example

  example2:
    handler: handler.example
    vpcDiscovery:
      vpcName: '<vpc name>
      subnetNames:
        - '<name of subnet>'
      securityGroupNames:
        - '<name of security group>'
...
```

![Screen Shot 2020-12-01 at 10 36 38 AM](https://user-images.githubusercontent.com/4427554/100718444-04ad3980-33c4-11eb-9b46-debd31d17d02.png)
