### PR TITLE
Add support for AWS wildcards in Subnet and SecurityGroup names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.3.0] - 2020-12-10
+## [2.3.0] - 2020-12-11
 ### Changed
 - Allow usage of wildcards in subnet and security group names. Thank you @RLRabinowitz ([#41](https://github.com/amplify-education/serverless-vpc-discovery/pull/41))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.3.0] - 2020-12-10
 ### Changed
-- Allow usage of wildcards in subnet and security group names. Thank you @RLRabinowitz (#41)
+- Allow usage of wildcards in subnet and security group names. Thank you @RLRabinowitz ([#41](https://github.com/amplify-education/serverless-vpc-discovery/pull/41))
 
 ## [2.2.1] - 2020-12-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2020-12-10
+### Changed
+- Allow usage of wildcards in subnet and security group names
+
 ## [2.2.1] - 2020-12-02
 ### Changed
 - Fixed travis build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.3.0] - 2020-12-10
 ### Changed
-- Allow usage of wildcards in subnet and security group names
+- Allow usage of wildcards in subnet and security group names. Thank you @RLRabinowitz (#41)
 
 ## [2.2.1] - 2020-12-02
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-vpc-discovery",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "engines": {
     "node": ">=4.0"
   },

--- a/src/aws/ec2-wrapper.ts
+++ b/src/aws/ec2-wrapper.ts
@@ -1,5 +1,5 @@
 import { EC2 } from "aws-sdk";
-import { getAWSPagedResults } from "../utils";
+import { getAWSPagedResults, arnMatches } from "../utils";
 import { VPC, VPCDiscovery } from "../types";
 
 export class EC2Wrapper {
@@ -87,7 +87,7 @@ export class EC2Wrapper {
       // collect subnets by name
       const subnetsByName = subnets.filter((subnet) => {
         const nameTag = subnet.Tags.find((tag) => tag.Key === "Name");
-        return nameTag.Value === subnetName;
+        return arnMatches(subnetName, nameTag.Value);
       });
       return subnetsByName.length === 0;
     });
@@ -134,7 +134,7 @@ export class EC2Wrapper {
     const missingGroupsNames = securityGroupNames.filter((groupName) => {
       // collect security groups by name
       const securityGroupsByName = securityGroups.filter((securityGroup) => {
-        return securityGroup.GroupName === groupName;
+        return arnMatches(groupName, securityGroup.GroupName);
       });
       return securityGroupsByName.length === 0;
     });

--- a/src/aws/ec2-wrapper.ts
+++ b/src/aws/ec2-wrapper.ts
@@ -1,5 +1,5 @@
 import { EC2 } from "aws-sdk";
-import { getAWSPagedResults, arnMatches } from "../utils";
+import { getAWSPagedResults, wildcardMatches } from "../utils";
 import { VPC, VPCDiscovery } from "../types";
 
 export class EC2Wrapper {
@@ -87,7 +87,7 @@ export class EC2Wrapper {
       // collect subnets by name
       const subnetsByName = subnets.filter((subnet) => {
         const nameTag = subnet.Tags.find((tag) => tag.Key === "Name");
-        return arnMatches(subnetName, nameTag.Value);
+        return wildcardMatches(subnetName, nameTag.Value);
       });
       return subnetsByName.length === 0;
     });
@@ -134,7 +134,7 @@ export class EC2Wrapper {
     const missingGroupsNames = securityGroupNames.filter((groupName) => {
       // collect security groups by name
       const securityGroupsByName = securityGroups.filter((securityGroup) => {
-        return arnMatches(groupName, securityGroup.GroupName);
+        return wildcardMatches(groupName, securityGroup.GroupName);
       });
       return securityGroupsByName.length === 0;
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,9 +80,22 @@ function isObjectEmpty (object: Object): boolean {
   return Object.keys(object).length === 0;
 }
 
+function arnMatches (inputArn: string, actualArn: string) {
+  const noColon = "[^:]";
+  const inputArnRegexStr = replaceAll(replaceAll(inputArn, "?", noColon), "*", `${noColon}*`);
+  const inputArnRegex = new RegExp(`^${inputArnRegexStr}$`);
+
+  return inputArnRegex.test(actualArn);
+}
+
+function replaceAll (input: string, search: string, replace: string) {
+  return input.split(search).join(replace);
+}
+
 export {
   sleep,
   getAWSPagedResults,
   throttledCall,
-  isObjectEmpty
+  isObjectEmpty,
+  arnMatches
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -84,7 +84,7 @@ function replaceAll (input: string, search: string, replace: string) {
   return input.split(search).join(replace);
 }
 
-function arnMatches (inputArn: string, actualArn: string) {
+function wildcardMatches (inputArn: string, actualArn: string) {
   const noColon = "[^:]";
   const inputArnRegexStr = replaceAll(replaceAll(inputArn, "?", noColon), "*", `${noColon}*`);
   const inputArnRegex = new RegExp(`^${inputArnRegexStr}$`);
@@ -97,5 +97,5 @@ export {
   getAWSPagedResults,
   throttledCall,
   isObjectEmpty,
-  arnMatches
+  wildcardMatches
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,6 +87,7 @@ function replaceAll (input: string, search: string, replace: string) {
 function arnMatches (inputArn: string, actualArn: string) {
   const noColon = "[^:]";
   const inputArnRegexStr = replaceAll(replaceAll(inputArn, "?", noColon), "*", `${noColon}*`);
+  // eslint-disable-next-line security/detect-non-literal-regexp
   const inputArnRegex = new RegExp(`^${inputArnRegexStr}$`);
 
   return inputArnRegex.test(actualArn);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,7 +87,6 @@ function replaceAll (input: string, search: string, replace: string) {
 function arnMatches (inputArn: string, actualArn: string) {
   const noColon = "[^:]";
   const inputArnRegexStr = replaceAll(replaceAll(inputArn, "?", noColon), "*", `${noColon}*`);
-  // eslint-disable-next-line security/detect-non-literal-regexp
   const inputArnRegex = new RegExp(`^${inputArnRegexStr}$`);
 
   return inputArnRegex.test(actualArn);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,16 +80,16 @@ function isObjectEmpty (object: Object): boolean {
   return Object.keys(object).length === 0;
 }
 
+function replaceAll (input: string, search: string, replace: string) {
+  return input.split(search).join(replace);
+}
+
 function arnMatches (inputArn: string, actualArn: string) {
   const noColon = "[^:]";
   const inputArnRegexStr = replaceAll(replaceAll(inputArn, "?", noColon), "*", `${noColon}*`);
   const inputArnRegex = new RegExp(`^${inputArnRegexStr}$`);
 
   return inputArnRegex.test(actualArn);
-}
-
-function replaceAll (input: string, search: string, replace: string) {
-  return input.split(search).join(replace);
 }
 
 export {

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -216,12 +216,6 @@ describe("Given input missing in AWS for ", () => {
     plugin.initResources();
   });
 
-  const funcVPCDiscovery: FuncVPCDiscovery = {
-    vpcName: "test",
-    subnetNames: ["test_subnet_*"],
-    securityGroupNames: ["test_group_*"]
-  };
-
   it('Subnets', async () => {
     const funcVPCDiscovery: FuncVPCDiscovery = {
       vpcName: "test",

--- a/test/unit-tests/index.test.ts
+++ b/test/unit-tests/index.test.ts
@@ -120,19 +120,35 @@ describe("Given a vpc,", () => {
   });
 });
 
-describe("Given valid inputs for ", () => {
-  it("Subnets", async () => {
+describe("Given valid inputs for Subnets and Security Groups ", () => {
+  let plugin;
+  beforeEach(() => {
     AWS.mock("EC2", "describeVpcs", testData);
     AWS.mock("EC2", "describeSecurityGroups", testData);
     AWS.mock("EC2", "describeSubnets", testData);
 
-    const plugin = constructPlugin({});
+    plugin = constructPlugin({});
     plugin.initResources();
+  })
 
+  it("without wildcards", async () => {
     const funcVPCDiscovery: FuncVPCDiscovery = {
       vpcName: "test",
       subnetNames: ["test_subnet_1", "test_subnet_2", "test_subnet_3"],
       securityGroupNames: ["test_group_1"]
+    };
+
+    await plugin.lambdaFunction.getFuncVPC("test", funcVPCDiscovery).then((vpc) => {
+      expect(vpc.subnetIds).to.have.members(["subnet-test-1", "subnet-test-2", "subnet-test-3"]);
+      expect(vpc.securityGroupIds).to.have.members(["sg-test"]);
+    });
+  });
+
+  it("with wildcards", async () => {
+    const funcVPCDiscovery: FuncVPCDiscovery = {
+      vpcName: "test",
+      subnetNames: ["test_subnet_*"],
+      securityGroupNames: ["test_group_*"]
     };
 
     await plugin.lambdaFunction.getFuncVPC("test", funcVPCDiscovery).then((vpc) => {
@@ -188,6 +204,56 @@ describe("Given invalid input for ", () => {
     AWS.restore();
   });
 });
+
+describe("Given input missing in AWS for ", () => {
+  let plugin;
+  beforeEach(() => {
+    AWS.mock("EC2", "describeVpcs", testData);
+    AWS.mock("EC2", "describeSubnets", testData);
+    AWS.mock("EC2", "describeSecurityGroups", testData);
+
+    plugin = constructPlugin({});
+    plugin.initResources();
+  });
+
+  const funcVPCDiscovery: FuncVPCDiscovery = {
+    vpcName: "test",
+    subnetNames: ["test_subnet_*"],
+    securityGroupNames: ["test_group_*"]
+  };
+
+  it('Subnets', async () => {
+    const funcVPCDiscovery: FuncVPCDiscovery = {
+      vpcName: "test",
+      subnetNames: ["test_subnet_*", "missing_subnet"],
+      securityGroupNames: ["test_group_*"]
+    };
+
+    await plugin.lambdaFunction.getFuncVPC("test", funcVPCDiscovery).then(() => {
+      throw new Error("Test has failed. Security Groups were created with invalid inputs");
+    }, (err) => {
+      expect(err.message).to.equal("Subnets do not exist for the names: missing_subnet. Please check the names are correct or remove it.");
+    });
+  })
+
+  it('Security Groups', async () => {
+    const funcVPCDiscovery: FuncVPCDiscovery = {
+      vpcName: "test",
+      subnetNames: ["test_subnet_*"],
+      securityGroupNames: ["test_group_*", "missing_security_group"]
+    };
+
+    await plugin.lambdaFunction.getFuncVPC("test", funcVPCDiscovery).then(() => {
+      throw new Error("Test has failed. Security Groups were created with invalid inputs");
+    }, (err) => {
+      expect(err.message).to.equal("Security groups do not exist for the names: missing_security_group. Please check the names are correct or remove it.");
+    });
+  })
+
+  afterEach(() => {
+    AWS.restore();
+  });
+})
 
 describe("Catching errors in updateVpcConfig ", () => {
   it("AWS api call describeVpcs fails", async () => {


### PR DESCRIPTION
Support AWS wildcards in Subnet and Security Group names.

For every Subnet and Security Group defined as an input to the plugin, we make sure that AWS has found a corresponding Subnet/Security Group. In order to keep supporting this check with wildcards, we will make sure that every `subnetName` and `securityGroupName` has at least one match in AWS using the [AWS wildcard logic](https://docs.aws.amazon.com/AmazonS3/latest/dev/s3-arn-format.html)

Fixes #29 